### PR TITLE
chore: add new min age for major updates, hoist existing npm rule

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,6 +6,12 @@
   ],
   "packageRules": [
     {
+      "internalChecksFilter": "strict",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days",
+      "prCreation": "not-pending"
+    },
+    {
       "groupName": "All patch dependencies",
       "groupSlug": "all-patch-dependencies",
       "matchPackagePatterns": ["*"],
@@ -26,8 +32,10 @@
     {
       "groupName": "All major dependencies",
       "groupSlug": "all-major-dependencies",
+      "internalChecksFilter": "strict",
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "90 days",
       "schedule": [
         "every 3 months on the first day of the month"
       ]


### PR DESCRIPTION
Staggers major dependency updates by 90 days
- The general idea is to simplify the process of 1) deciding whether or not to proceed with a major version upgrade and 2) actually performing that integration
- The hope is that a longer lead time will give maintainers more time to address issues from consumers and either have a more compatible version or better documented path to adoption. Worst case, at least more immediate clarity on deciding to punt a major version to the following quarter.
- The 90-day window and the overall rule itself is fairly arbitrary, and should be considered somewhat experimental for what we're going for. We can make tweaks based on our findings.

Hoists renovate-recommended rule for `minimumReleaseAge` on npm packages to make it global
- Just making this DRY - there's no need to repeat it in npm based projects
- Once this PR is merged, I'll do the work in the related projects to remove this rule
